### PR TITLE
Add FreeBSD RIDs to known targets

### DIFF
--- a/src/redist/targets/GenerateBundledVersions.targets
+++ b/src/redist/targets/GenerateBundledVersions.targets
@@ -105,6 +105,7 @@
       <Net60AppHostRids Include="
           @(Net50AppHostRids);
           osx-arm64;
+          freebsd-x64;
           "/>
 
       <Net60RuntimePackRids Include="
@@ -112,6 +113,7 @@
           osx-arm64;
           maccatalyst-x64;
           maccatalyst-arm64;
+          freebsd-x64;
           " />
 
       <!-- In .NET 6 the browser-wasm runtime pack started using the Mono naming pattern -->


### PR DESCRIPTION
This implements [the changes](https://github.com/dotnet/runtime/issues/14537#issuecomment-917813061) suggested by @jasonpugsley to fix the following error when trying to install .NET on FreeBSD:

`NETSDK1084: There is no application host available for the specified RuntimeIdentifier freebsd-x64`
